### PR TITLE
Extract the Correct Account Number & MSISDN from MTN Paybill Payload - CP-3769

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.1.0] - 2024-11-22
+## [1.1.1] - 2025-08-05
+### Fixed
+- [CP-3769](https://oneacrefund.atlassian.net/browse/CP-3769) Extract the Correct Account Number & MSISDN from MTN Paybill Payload
+
+## [1.1.0] - 2025-05-16
 ### Added
 - [CP-3553](https://oneacrefund.atlassian.net/browse/CP-3553) Implement MTN Paybill flow
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
     id 'jacoco'
 }
 group = 'org.mifos.connector'
-version = '1.1.0'
+version = '1.1.1'
 sourceCompatibility = '17'
 def camelCoreVersion = '3.12.0'
 repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,9 @@ repositories {
     maven {
         url = uri('https://secure-api.oneacrefund.org/s3/artifacts')
     }
+    maven {
+        url = uri('https://mifos.jfrog.io/artifactory/phee-gradle-local')
+    }
 }
 
 dependencies {
@@ -26,7 +29,7 @@ dependencies {
     implementation 'org.apache.camel:camel-http:3.12.0'
     implementation 'io.camunda:zeebe-client-java:8.1.9'
     implementation 'org.json:json:20230227'
-    implementation 'org.mifos:ph-ee-connector-common:1.5.1-SNAPSHOT'
+    implementation 'org.mifos:ph-ee-connector-common:1.5.1-gazelle'
     implementation 'org.apache.camel.springboot:camel-jackson-starter:3.12.0'
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.14.2'
     implementation "org.apache.camel.springboot:camel-jaxb-starter:${camelCoreVersion}"

--- a/src/main/java/org/mifos/connector/mtn/camel/config/CamelProperties.java
+++ b/src/main/java/org/mifos/connector/mtn/camel/config/CamelProperties.java
@@ -34,5 +34,7 @@ public class CamelProperties {
     public static final String CONFIRMATION_REQUEST_BODY = "confirmationRequestBody";
     public static final String MTN_PAYBILL_WORKFLOW_TYPE = "mtn";
     public static final String MTN_PAYBILL_WORKFLOW_SUBTYPE = "inbound";
+    public static final String PAYBILL_ACCOUNT_NUMBER_EXTRACTION_REGEX = "^FRI:|@.*$";
+    public static final String PAYBILL_MSISDN_EXTRACTION_REGEX = "^ID:|/MSISDN$";
 
 }

--- a/src/main/java/org/mifos/connector/mtn/dto/ChannelConfirmationRequest.java
+++ b/src/main/java/org/mifos/connector/mtn/dto/ChannelConfirmationRequest.java
@@ -1,6 +1,8 @@
 package org.mifos.connector.mtn.dto;
 
 import static org.mifos.connector.mtn.camel.config.CamelProperties.SECONDARY_IDENTIFIER_NAME;
+import static org.mifos.connector.mtn.utility.MtnUtils.extractPaybillAccountNumber;
+import static org.mifos.connector.mtn.utility.MtnUtils.extractPaybillMsisdn;
 
 import org.json.JSONObject;
 
@@ -23,13 +25,13 @@ public record ChannelConfirmationRequest(JSONObject payer, JSONObject payee, JSO
         JSONObject payer = new JSONObject();
         JSONObject partyIdInfoPayer = new JSONObject();
         partyIdInfoPayer.put("partyIdType", SECONDARY_IDENTIFIER_NAME);
-        partyIdInfoPayer.put("partyIdentifier", request.getAccountHolderId());
+        partyIdInfoPayer.put("partyIdentifier", extractPaybillMsisdn(request.getAccountHolderId()));
         payer.put("partyIdInfo", partyIdInfoPayer);
 
         JSONObject payee = new JSONObject();
         JSONObject partyIdInfoPayee = new JSONObject();
         partyIdInfoPayee.put("partyIdType", paybillProps.getAmsIdentifier());
-        partyIdInfoPayee.put("partyIdentifier", request.getReceivingFri());
+        partyIdInfoPayee.put("partyIdentifier", extractPaybillAccountNumber(request.getReceivingFri()));
         payee.put("partyIdInfo", partyIdInfoPayee);
 
         JSONObject amount = new JSONObject();

--- a/src/main/java/org/mifos/connector/mtn/dto/ChannelValidationRequest.java
+++ b/src/main/java/org/mifos/connector/mtn/dto/ChannelValidationRequest.java
@@ -3,6 +3,8 @@ package org.mifos.connector.mtn.dto;
 import static org.mifos.connector.mtn.camel.config.CamelProperties.CURRENCY;
 import static org.mifos.connector.mtn.camel.config.CamelProperties.GET_ACCOUNT_DETAILS_FLAG;
 import static org.mifos.connector.mtn.camel.config.CamelProperties.SECONDARY_IDENTIFIER_NAME;
+import static org.mifos.connector.mtn.utility.MtnUtils.extractPaybillAccountNumber;
+import static org.mifos.connector.mtn.utility.MtnUtils.extractPaybillMsisdn;
 import static org.mifos.connector.mtn.zeebe.ZeebeVariables.TRANSACTION_ID;
 
 import java.util.List;
@@ -27,8 +29,10 @@ public record ChannelValidationRequest(CustomData primaryIdentifier, CustomData 
      */
     public static ChannelValidationRequest fromPaybillValidation(FinancialResourceInformationRequest request,
             PaybillProps paybillProps, String transactionId) {
-        CustomData primaryIdentifier = new CustomData(paybillProps.getAmsIdentifier(), request.getResource());
-        CustomData secondaryIdentifier = new CustomData(SECONDARY_IDENTIFIER_NAME, request.getAccountHolderId());
+        CustomData primaryIdentifier = new CustomData(paybillProps.getAmsIdentifier(),
+                extractPaybillAccountNumber(request.getResource()));
+        CustomData secondaryIdentifier = new CustomData(SECONDARY_IDENTIFIER_NAME,
+                extractPaybillMsisdn(request.getAccountHolderId()));
         CustomData txnId = new CustomData(TRANSACTION_ID, transactionId);
         CustomData currency = new CustomData(CURRENCY, paybillProps.getCurrency());
         CustomData getAccountDetails = new CustomData(GET_ACCOUNT_DETAILS_FLAG, Boolean.TRUE);

--- a/src/main/java/org/mifos/connector/mtn/dto/FinancialResourceInformationRequest.java
+++ b/src/main/java/org/mifos/connector/mtn/dto/FinancialResourceInformationRequest.java
@@ -13,7 +13,7 @@ import lombok.Setter;
  */
 @Getter
 @Setter
-@XmlRootElement(name = "getfinancialresourceinformationrequest", namespace = "http://www.ericsson.com/em/emm/serviceprovider/v1_0/frontend")
+@XmlRootElement(name = "getfinancialresourceinformationrequest", namespace = "http://www.ericsson.com/em/emm/serviceprovider/v1_0/backend/client")
 @XmlAccessorType(XmlAccessType.FIELD)
 public class FinancialResourceInformationRequest {
 

--- a/src/main/java/org/mifos/connector/mtn/flowcomponents/state/PaybillConfirmationProcessor.java
+++ b/src/main/java/org/mifos/connector/mtn/flowcomponents/state/PaybillConfirmationProcessor.java
@@ -6,6 +6,8 @@ import static org.mifos.connector.mtn.camel.config.CamelProperties.CONFIRMATION_
 import static org.mifos.connector.mtn.camel.config.CamelProperties.CORRELATION_ID;
 import static org.mifos.connector.mtn.camel.config.CamelProperties.MTN_PAYBILL_WORKFLOW_SUBTYPE;
 import static org.mifos.connector.mtn.camel.config.CamelProperties.MTN_PAYBILL_WORKFLOW_TYPE;
+import static org.mifos.connector.mtn.utility.MtnUtils.extractPaybillAccountNumber;
+import static org.mifos.connector.mtn.utility.MtnUtils.extractPaybillMsisdn;
 import static org.mifos.connector.mtn.utility.MtnUtils.getWorkflowId;
 import static org.mifos.connector.mtn.zeebe.ZeebeVariables.CLIENT_CORRELATION_ID;
 import static org.mifos.connector.mtn.zeebe.ZeebeVariables.CONFIRMATION_RECEIVED;
@@ -59,12 +61,12 @@ public class PaybillConfirmationProcessor implements Processor {
         Map<String, Object> variables = new HashMap<>();
         variables.put(CONFIRMATION_RECEIVED, true);
         variables.put(CHANNEL_REQUEST, channelConfirmationRequest.toString());
-        variables.put(paybillProps.getAmsIdentifier(), paymentRequest.getReceivingFri());
+        variables.put(paybillProps.getAmsIdentifier(), extractPaybillAccountNumber(paymentRequest.getReceivingFri()));
         variables.put(TRANSACTION_ID, paymentRequest.getOafReference());
         variables.put(CORRELATION_ID, workflowTransactionId);
         variables.put(EXTERNAL_ID, paymentRequest.getTransactionId());
         variables.put(TRANSFER_CREATE_FAILED, false);
-        variables.put("phoneNumber", paymentRequest.getAccountHolderId());
+        variables.put("phoneNumber", extractPaybillMsisdn(paymentRequest.getAccountHolderId()));
         variables.put("amount", paymentRequest.getAmount().getAmount());
         if (workflowTransactionId != null) {
             zeebeClient.newPublishMessageCommand().messageName(PENDING_CONFIRMATION_MESSAGE_NAME)

--- a/src/main/java/org/mifos/connector/mtn/utility/MtnUtils.java
+++ b/src/main/java/org/mifos/connector/mtn/utility/MtnUtils.java
@@ -1,6 +1,8 @@
 package org.mifos.connector.mtn.utility;
 
 import static org.mifos.connector.mtn.camel.config.CamelProperties.CURRENCY;
+import static org.mifos.connector.mtn.camel.config.CamelProperties.PAYBILL_ACCOUNT_NUMBER_EXTRACTION_REGEX;
+import static org.mifos.connector.mtn.camel.config.CamelProperties.PAYBILL_MSISDN_EXTRACTION_REGEX;
 import static org.mifos.connector.mtn.camel.config.CamelProperties.SECONDARY_IDENTIFIER_NAME;
 import static org.mifos.connector.mtn.zeebe.ZeebeVariables.AMS;
 import static org.mifos.connector.mtn.zeebe.ZeebeVariables.CLIENT_CORRELATION_ID;
@@ -22,6 +24,7 @@ import org.mifos.connector.mtn.dto.ChannelValidationResponse;
 import org.mifos.connector.mtn.dto.Payer;
 import org.mifos.connector.mtn.dto.PaymentRequestDto;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 
 /**
  * Mtn utilities class.
@@ -143,5 +146,43 @@ public class MtnUtils {
             String accountHoldingInstitutionId) {
         return subtype + "_" + type + "_" + amsName + "-" + accountHoldingInstitutionId;
 
+    }
+
+    /**
+     * Extracts a value from the input string based on the provided regex.
+     *
+     * @param input
+     *            the input string
+     * @param regex
+     *            the regex pattern for the extraction
+     * @return the extracted value or null if the input is blank
+     */
+    private static String extractValue(String input, String regex) {
+        if (!StringUtils.hasText(input)) {
+            return null;
+        }
+        return input.trim().replaceAll(regex, "");
+    }
+
+    /**
+     * Extracts the paybill account number from the input string.
+     *
+     * @param input
+     *            the input string
+     * @return the extracted account number or null if the input is blank
+     */
+    public static String extractPaybillAccountNumber(String input) {
+        return extractValue(input, PAYBILL_ACCOUNT_NUMBER_EXTRACTION_REGEX);
+    }
+
+    /**
+     * Extracts the paybill MSISDN from the input string.
+     *
+     * @param input
+     *            the input string
+     * @return the extracted MSISDN or null if the input is blank
+     */
+    public static String extractPaybillMsisdn(String input) {
+        return extractValue(input, PAYBILL_MSISDN_EXTRACTION_REGEX);
     }
 }

--- a/src/test/java/org/mifos/connector/mtn/camel/routes/PaybillRouteBuilderTest.java
+++ b/src/test/java/org/mifos/connector/mtn/camel/routes/PaybillRouteBuilderTest.java
@@ -77,9 +77,9 @@ public class PaybillRouteBuilderTest extends MtnConnectorApplicationTests {
         Exchange exchange = new DefaultExchange(camelContext);
         String requestBody = """
                 <?xml version="1.0" encoding="UTF-8"?>
-                <ns0:getfinancialresourceinformationrequest xmlns:ns0="http://www.ericsson.com/em/emm/serviceprovider/v1_0/frontend">
-                   <resource>15834384</resource>
-                   <accountholderid>250790690134</accountholderid>
+                <ns0:getfinancialresourceinformationrequest xmlns:ns0="http://www.ericsson.com/em/emm/serviceprovider/v1_0/backend/client">
+                   <resource>FRI:15834384@tubura.sp/SP</resource>
+                   <accountholderid>ID:250790690134/MSISDN</accountholderid>
                 </ns0:getfinancialresourceinformationrequest>
                     """;
         exchange.getIn().setBody(requestBody);
@@ -124,7 +124,7 @@ public class PaybillRouteBuilderTest extends MtnConnectorApplicationTests {
         Exchange exchange = new DefaultExchange(camelContext);
         String requestBody = """
                 <?xml version="1.0" encoding="UTF-8"?>
-                <ns0:getfinancialresourceinformationrequest xmlns:ns0="http://www.ericsson.com/em/emm/serviceprovider/v1_0/frontend">
+                <ns0:getfinancialresourceinformationrequest xmlns:ns0="http://www.ericsson.com/em/emm/serviceprovider/v1_0/backend/client">
                    <resource>15834384</resource>
                    <accountholderid>250790690134</accountholderid>
                 </ns0:getfinancialresourceinformationrequest>
@@ -154,7 +154,7 @@ public class PaybillRouteBuilderTest extends MtnConnectorApplicationTests {
         Exchange exchange = new DefaultExchange(camelContext);
         String requestBody = """
                 <?xml version="1.0" encoding="UTF-8"?>
-                <ns0:getfinancialresourceinformationrequest xmlns:ns0="http://www.ericsson.com/em/emm/serviceprovider/v1_0/frontend">
+                <ns0:getfinancialresourceinformationrequest xmlns:ns0="http://www.ericsson.com/em/emm/serviceprovider/v1_0/backend/client">
                    <resource>15834384</resource>
                    <accountholderid>250790690134</accountholderid>
                 </ns0:getfinancialresourceinformationrequest>

--- a/src/test/java/org/mifos/connector/mtn/utility/MtnUtilsTest.java
+++ b/src/test/java/org/mifos/connector/mtn/utility/MtnUtilsTest.java
@@ -1,8 +1,12 @@
 package org.mifos.connector.mtn.utility;
 
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mifos.connector.common.channel.dto.TransactionChannelC2BRequestDTO;
 import org.mifos.connector.common.gsma.dto.GsmaParty;
 import org.mifos.connector.common.mojaloop.dto.MoneyData;
@@ -98,6 +102,46 @@ class MtnUtilsTest extends MtnConnectorApplicationTests {
         Assertions.assertEquals("test-transaction-id", result.getExternalId());
         Assertions.assertEquals("Test Message", result.getPayerMessage());
         Assertions.assertEquals("Test Message", result.getPayeeNote());
+    }
+
+    @ParameterizedTest
+    @MethodSource("validPaybillAccountNumbers")
+    void extractPaybillAccountNumber_whenInputIsValid_shouldExtractCorrectValue(String input, String expected) {
+        Assertions.assertEquals(expected, MtnUtils.extractPaybillAccountNumber(input));
+    }
+
+    @ParameterizedTest
+    @MethodSource("invalidPaybillValues")
+    void extractPaybillAccountNumber_whenInputIsInvalid_shouldReturnNull(String input, String expected) {
+        Assertions.assertEquals(expected, MtnUtils.extractPaybillAccountNumber(input));
+    }
+
+    @ParameterizedTest
+    @MethodSource("validMsisdnValues")
+    void extractPaybillMsisdn_whenInputIsValid_shouldExtractCorrectValue(String input, String expected) {
+        Assertions.assertEquals(expected, MtnUtils.extractPaybillMsisdn(input));
+    }
+
+    @ParameterizedTest
+    @MethodSource("validMsisdnValues")
+    void extractPaybillMsisdn_whenInputIsInvalid_shouldReturnNull(String input, String expected) {
+        Assertions.assertEquals(expected, MtnUtils.extractPaybillMsisdn(input));
+    }
+
+    private static Stream<Arguments> validPaybillAccountNumbers() {
+        return Stream.of(Arguments.of("FRI:33859939@tubura.sp/SP", "33859939"),
+                Arguments.of("FRI:12345@some.domain/SP", "12345"), Arguments.of("FRI:987654321@x.y.z", "987654321"),
+                Arguments.of("   FRI:1111@domain/SP   ", "1111"), Arguments.of("33859939", "33859939"));
+    }
+
+    private static Stream<Arguments> invalidPaybillValues() {
+        return Stream.of(Arguments.of("", null), Arguments.of("   ", null), Arguments.of(null, null));
+    }
+
+    public static Stream<Arguments> validMsisdnValues() {
+        return Stream.of(Arguments.of("ID:250790690134/MSISDN", "250790690134"),
+                Arguments.of("ID:12345/MSISDN", "12345"), Arguments.of("   ID:987654321/MSISDN   ", "987654321"),
+                Arguments.of("987654321/MSISDN   ", "987654321"), Arguments.of("987654321", "987654321"));
     }
 
 }

--- a/src/test/java/org/mifos/connector/mtn/utility/MtnUtilsTest.java
+++ b/src/test/java/org/mifos/connector/mtn/utility/MtnUtilsTest.java
@@ -123,7 +123,7 @@ class MtnUtilsTest extends MtnConnectorApplicationTests {
     }
 
     @ParameterizedTest
-    @MethodSource("validMsisdnValues")
+    @MethodSource("invalidPaybillValues")
     void extractPaybillMsisdn_whenInputIsInvalid_shouldReturnNull(String input, String expected) {
         Assertions.assertEquals(expected, MtnUtils.extractPaybillMsisdn(input));
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved extraction of account number and MSISDN from MTN Paybill payloads, ensuring correct information is processed during paybill transactions.
  * Updated XML namespace in paybill requests for compatibility with backend systems.

* **Chores**
  * Updated project version to 1.1.1 and changelog to reflect latest changes.
  * Updated dependency versions and repository configuration.

* **Tests**
  * Added comprehensive tests to validate extraction of paybill account numbers and MSISDNs, covering various input scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->