### PR TITLE
Move oafReference inside extension in MTN payment payload - CP-3774

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.2] - 2025-08-07
+### Changed
+- [CP-3774](https://oneacrefund.atlassian.net/browse/CP-3774) Move oafReference inside extension in MTN payment payload
+
 ## [1.1.1] - 2025-08-05
 ### Fixed
 - [CP-3769](https://oneacrefund.atlassian.net/browse/CP-3769) Extract the Correct Account Number & MSISDN from MTN Paybill Payload

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
     id 'jacoco'
 }
 group = 'org.mifos.connector'
-version = '1.1.1'
+version = '1.1.2'
 sourceCompatibility = '17'
 def camelCoreVersion = '3.12.0'
 repositories {

--- a/src/main/java/org/mifos/connector/mtn/camel/routes/PaybillRouteBuilder.java
+++ b/src/main/java/org/mifos/connector/mtn/camel/routes/PaybillRouteBuilder.java
@@ -192,7 +192,8 @@ public class PaybillRouteBuilder extends RouteBuilder {
 
         from("direct:paybill-confirmation-base").id("paybill-confirmation-base")
                 .to("bean-validator:confirmation-request-validator")
-                .log("Received mtn confirmation request with transaction id: ${body.oafReference}," + " body: ${body} ")
+                .log("Received mtn confirmation request with transaction id: ${body.extension.oafReference},"
+                        + " body: ${body} ")
                 .setProperty(CONFIRMATION_REQUEST_BODY, simple("${body}"))
                 .to("direct:paybill-transaction-status-check-base").choice().when(exchange -> {
                     TransactionStatusResponseDTO transactionStatusResponse = exchange.getIn()
@@ -205,7 +206,7 @@ public class PaybillRouteBuilder extends RouteBuilder {
                             PaybillPaymentRequest.class);
                     PaybillPaymentResponse response = new PaybillPaymentResponse();
                     response.setStatus("PENDING");
-                    response.setProviderTransactionId(paymentRequest.getOafReference());
+                    response.setProviderTransactionId(paymentRequest.getExtension().getOafReference());
                     exchange.getIn().setHeader(HTTP_RESPONSE_CODE, 202);
                     exchange.getIn().setHeader(CONTENT_TYPE, MediaType.APPLICATION_XML_VALUE);
                     exchange.getIn().setBody(response);
@@ -215,7 +216,7 @@ public class PaybillRouteBuilder extends RouteBuilder {
                 .process(exchange -> {
                     PaybillPaymentRequest paymentRequest = exchange.getProperty(CONFIRMATION_REQUEST_BODY,
                             PaybillPaymentRequest.class);
-                    exchange.setProperty(TRANSACTION_ID, paymentRequest.getOafReference());
+                    exchange.setProperty(TRANSACTION_ID, paymentRequest.getExtension().getOafReference());
                     exchange.getIn().removeHeaders("*");
                     exchange.getIn().setBody(null);
                     exchange.getIn().setHeader(PLATFORM_TENANT_ID, paybillProps.getAccountHoldingInstitutionId());

--- a/src/main/java/org/mifos/connector/mtn/dto/PaybillPaymentRequest.java
+++ b/src/main/java/org/mifos/connector/mtn/dto/PaybillPaymentRequest.java
@@ -39,8 +39,9 @@ public class PaybillPaymentRequest {
     @XmlElement(name = "transmissioncounter")
     private int transmissionCounter;
 
-    @NotBlank
-    private String oafReference;
+    @NotNull
+    @Valid
+    private Extension extension;
 
     /**
      * Amount class representing the amount and currency information.
@@ -55,5 +56,16 @@ public class PaybillPaymentRequest {
 
         @NotBlank
         private String currency;
+    }
+
+    /**
+     * Extension class for additional properties.
+     */
+    @Getter
+    @Setter
+    public static class Extension {
+
+        @NotBlank
+        private String oafReference;
     }
 }

--- a/src/test/java/org/mifos/connector/mtn/camel/routes/PaybillRouteBuilderTest.java
+++ b/src/test/java/org/mifos/connector/mtn/camel/routes/PaybillRouteBuilderTest.java
@@ -188,7 +188,8 @@ public class PaybillRouteBuilderTest extends MtnConnectorApplicationTests {
         paymentRequest.setTransactionId("1025552");
         paymentRequest.setAccountHolderId("250790690134");
         paymentRequest.setReceivingFri("15834384");
-        paymentRequest.setOafReference("5ef1933d-7daf-4214-857a-ff4ced7e0918");
+        paymentRequest.setExtension(new PaybillPaymentRequest.Extension());
+        paymentRequest.getExtension().setOafReference("5ef1933d-7daf-4214-857a-ff4ced7e0918");
         PaybillPaymentRequest.Amount amount = new PaybillPaymentRequest.Amount();
         amount.setAmount(BigDecimal.TEN);
         amount.setCurrency("RWF");
@@ -223,7 +224,8 @@ public class PaybillRouteBuilderTest extends MtnConnectorApplicationTests {
         paymentRequest.setTransactionId("1025552");
         paymentRequest.setAccountHolderId("250790690134");
         paymentRequest.setReceivingFri("15834384");
-        paymentRequest.setOafReference("5ef1933d-7daf-4214-857a-ff4ced7e0918");
+        paymentRequest.setExtension(new PaybillPaymentRequest.Extension());
+        paymentRequest.getExtension().setOafReference("5ef1933d-7daf-4214-857a-ff4ced7e0918");
         PaybillPaymentRequest.Amount amount = new PaybillPaymentRequest.Amount();
         amount.setAmount(BigDecimal.TEN);
         amount.setCurrency("RWF");
@@ -262,7 +264,8 @@ public class PaybillRouteBuilderTest extends MtnConnectorApplicationTests {
         paymentRequest.setTransactionId("1025552");
         paymentRequest.setAccountHolderId("250790690134");
         paymentRequest.setReceivingFri("15834384");
-        paymentRequest.setOafReference("5ef1933d-7daf-4214-857a-ff4ced7e0918");
+        paymentRequest.setExtension(new PaybillPaymentRequest.Extension());
+        paymentRequest.getExtension().setOafReference("5ef1933d-7daf-4214-857a-ff4ced7e0918");
         PaybillPaymentRequest.Amount amount = new PaybillPaymentRequest.Amount();
         amount.setAmount(BigDecimal.TEN);
         amount.setCurrency("RWF");

--- a/src/test/java/org/mifos/connector/mtn/flowcomponents/state/PaybillConfirmationProcessorTest.java
+++ b/src/test/java/org/mifos/connector/mtn/flowcomponents/state/PaybillConfirmationProcessorTest.java
@@ -103,13 +103,14 @@ class PaybillConfirmationProcessorTest {
         processor.process(exchange);
 
         verify(zeebeClient, times(1)).newPublishMessageCommand();
-        verify(workflowInstanceStore).remove(paymentRequest.getOafReference());
+        verify(workflowInstanceStore).remove(paymentRequest.getExtension().getOafReference());
     }
 
     private PaybillPaymentRequest createTestPaybillPaymentRequest() {
         PaybillPaymentRequest paymentRequest = new PaybillPaymentRequest();
         paymentRequest.setTransactionId("12345");
-        paymentRequest.setOafReference("try564rttt");
+        paymentRequest.setExtension(new PaybillPaymentRequest.Extension());
+        paymentRequest.getExtension().setOafReference("try564rttt");
         paymentRequest.setReceivingFri("FRI123");
         PaybillPaymentRequest.Amount amount = new PaybillPaymentRequest.Amount();
         amount.setAmount(BigDecimal.TEN);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the payment payload structure so that the "oafReference" field is now located within the "extension" section.
* **Bug Fixes**
  * Adjusted paybill confirmation and related flows to correctly reference the new location of "oafReference".
* **Documentation**
  * Added a changelog entry for version 1.1.2, detailing the structural update to the payment payload.
* **Tests**
  * Updated tests to reflect the new structure of the payment payload.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->