### PR TITLE
Fix/cp 3784 fix basic auth in payment completed request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.4] - 2025-08-11
+### Changed
+- [CP-3784](https://oneacrefund.atlassian.net/browse/CP-3784) MTN Paybill flow - Fix basic auth in payment completed request.
+
 ## [1.1.3] - 2025-08-11
 ### Changed
 - [CP-3784](https://oneacrefund.atlassian.net/browse/CP-3784) Modify the namespace for payment endpoint response to match the request namespace.

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
     id 'jacoco'
 }
 group = 'org.mifos.connector'
-version = '1.1.3'
+version = '1.1.4'
 sourceCompatibility = '17'
 def camelCoreVersion = '3.12.0'
 repositories {

--- a/src/main/java/org/mifos/connector/mtn/auth/AuthRoutes.java
+++ b/src/main/java/org/mifos/connector/mtn/auth/AuthRoutes.java
@@ -1,6 +1,6 @@
 package org.mifos.connector.mtn.auth;
 
-import static org.mifos.connector.mtn.utility.ConnectionUtils.createAuthHeader;
+import static org.mifos.connector.mtn.utility.ConnectionUtils.createBasicAuthHeaderValue;
 
 import java.time.LocalDateTime;
 import org.apache.camel.Exchange;
@@ -63,7 +63,7 @@ public class AuthRoutes extends RouteBuilder {
                 .setHeader("X-Target-Environment", constant(mtnProps.getEnvironment()))
                 .setHeader("Ocp-Apim-Subscription-Key", constant(mtnProps.getSubscriptionKey()))
                 .setHeader("Authorization",
-                        simple("Basic " + createAuthHeader(mtnProps.getClientKey(), mtnProps.getClientSecret())))
+                        simple(createBasicAuthHeaderValue(mtnProps.getClientKey(), mtnProps.getClientSecret())))
                 .toD(mtnProps.getAuthHost() + "/collection/token/" + "?bridgeEndpoint=true" + "&"
                         + "throwExceptionOnFailure=false&" + ConnectionUtils.getConnectionTimeoutDsl(mtnRwTimeout));
 

--- a/src/main/java/org/mifos/connector/mtn/auth/AuthRoutes.java
+++ b/src/main/java/org/mifos/connector/mtn/auth/AuthRoutes.java
@@ -1,8 +1,8 @@
 package org.mifos.connector.mtn.auth;
 
-import java.nio.charset.StandardCharsets;
+import static org.mifos.connector.mtn.utility.ConnectionUtils.createAuthHeader;
+
 import java.time.LocalDateTime;
-import java.util.Base64;
 import org.apache.camel.Exchange;
 import org.apache.camel.LoggingLevel;
 import org.apache.camel.builder.RouteBuilder;
@@ -15,8 +15,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
-
-import static org.mifos.connector.mtn.utility.ConnectionUtils.createAuthHeader;
 
 /**
  * Class for authentications routes.
@@ -79,6 +77,5 @@ public class AuthRoutes extends RouteBuilder {
                 .to("direct:access-token-save").otherwise().log("Access Token Fetch Unsuccessful")
                 .to("direct:access-token-error");
     }
-
 
 }

--- a/src/main/java/org/mifos/connector/mtn/auth/AuthRoutes.java
+++ b/src/main/java/org/mifos/connector/mtn/auth/AuthRoutes.java
@@ -16,6 +16,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
+import static org.mifos.connector.mtn.utility.ConnectionUtils.createAuthHeader;
+
 /**
  * Class for authentications routes.
  */
@@ -78,10 +80,5 @@ public class AuthRoutes extends RouteBuilder {
                 .to("direct:access-token-error");
     }
 
-    private String createAuthHeader(String key, String secret) {
-        key = key.replace("\n", "");
-        secret = secret.replace("\n", "");
-        byte[] credential = (key + ":" + secret).getBytes(StandardCharsets.UTF_8);
-        return Base64.getEncoder().encodeToString(credential);
-    }
+
 }

--- a/src/main/java/org/mifos/connector/mtn/camel/routes/PaybillRouteBuilder.java
+++ b/src/main/java/org/mifos/connector/mtn/camel/routes/PaybillRouteBuilder.java
@@ -12,7 +12,7 @@ import static org.mifos.connector.mtn.camel.config.CamelProperties.CORRELATION_I
 import static org.mifos.connector.mtn.camel.config.CamelProperties.PLATFORM_TENANT_ID;
 import static org.mifos.connector.mtn.camel.config.CamelProperties.PRIMARY_IDENTIFIER;
 import static org.mifos.connector.mtn.camel.config.CamelProperties.PRIMARY_IDENTIFIER_VALUE;
-import static org.mifos.connector.mtn.utility.ConnectionUtils.createAuthHeader;
+import static org.mifos.connector.mtn.utility.ConnectionUtils.createBasicAuthHeaderValue;
 import static org.mifos.connector.mtn.utility.MtnUtils.extractPaybillAccountNumber;
 import static org.mifos.connector.mtn.zeebe.ZeebeVariables.EXTERNAL_ID;
 import static org.mifos.connector.mtn.zeebe.ZeebeVariables.MTN_PAYMENT_COMPLETED;
@@ -248,7 +248,7 @@ public class PaybillRouteBuilder extends RouteBuilder {
                 + "body: ${body} ").setHeader(CONTENT_TYPE, constant(MediaType.APPLICATION_XML_VALUE))
                 .setHeader(Exchange.HTTP_METHOD, constant("POST"))
                 .setHeader("Authorization",
-                        simple("Basic " + createAuthHeader(paybillProps.getUsername(), paybillProps.getPassword())))
+                        constant(createBasicAuthHeaderValue(paybillProps.getUsername(), paybillProps.getPassword())))
                 .toD(paybillProps.getPaymentCompletedUrl() + BRIDGE_ENDPOINT_QUERY_PARAM + "&"
                         + ConnectionUtils.getConnectionTimeoutDsl(mtnTimeout))
                 .log("Received payment completed response ${header.CamelHttpResponseCode} for transaction"

--- a/src/main/java/org/mifos/connector/mtn/camel/routes/PaybillRouteBuilder.java
+++ b/src/main/java/org/mifos/connector/mtn/camel/routes/PaybillRouteBuilder.java
@@ -12,6 +12,7 @@ import static org.mifos.connector.mtn.camel.config.CamelProperties.CORRELATION_I
 import static org.mifos.connector.mtn.camel.config.CamelProperties.PLATFORM_TENANT_ID;
 import static org.mifos.connector.mtn.camel.config.CamelProperties.PRIMARY_IDENTIFIER;
 import static org.mifos.connector.mtn.camel.config.CamelProperties.PRIMARY_IDENTIFIER_VALUE;
+import static org.mifos.connector.mtn.utility.ConnectionUtils.createAuthHeader;
 import static org.mifos.connector.mtn.utility.MtnUtils.extractPaybillAccountNumber;
 import static org.mifos.connector.mtn.zeebe.ZeebeVariables.EXTERNAL_ID;
 import static org.mifos.connector.mtn.zeebe.ZeebeVariables.MTN_PAYMENT_COMPLETED;
@@ -246,9 +247,10 @@ public class PaybillRouteBuilder extends RouteBuilder {
         }).log("Sending mtn payment completed request with transaction id: ${exchangeProperty.transactionId}, "
                 + "body: ${body} ").setHeader(CONTENT_TYPE, constant(MediaType.APPLICATION_XML_VALUE))
                 .setHeader(Exchange.HTTP_METHOD, constant("POST"))
+                .setHeader("Authorization",
+                        simple("Basic " + createAuthHeader(paybillProps.getUsername(), paybillProps.getPassword())))
                 .toD(paybillProps.getPaymentCompletedUrl() + BRIDGE_ENDPOINT_QUERY_PARAM + "&"
-                        + ConnectionUtils.getConnectionTimeoutDsl(mtnTimeout) + "&authUsername="
-                        + paybillProps.getUsername() + "&authPassword=" + paybillProps.getPassword())
+                        + ConnectionUtils.getConnectionTimeoutDsl(mtnTimeout))
                 .log("Received payment completed response ${header.CamelHttpResponseCode} for transaction"
                         + " ${header.transactionId}: ${body}")
                 .setProperty(MTN_PAYMENT_COMPLETION_RESPONSE, simple("${bodyAs(String)}")).process(exchange -> {

--- a/src/main/java/org/mifos/connector/mtn/exception/MissingConfigurationException.java
+++ b/src/main/java/org/mifos/connector/mtn/exception/MissingConfigurationException.java
@@ -1,0 +1,18 @@
+package org.mifos.connector.mtn.exception;
+
+import org.springframework.http.HttpStatus;
+
+/**
+ * Exception thrown when a required configuration is missing in the MTN connector.
+ *
+ */
+public class MissingConfigurationException extends MtnConnectorException {
+
+    public MissingConfigurationException(String message) {
+        super(message, HttpStatus.BAD_REQUEST);
+    }
+
+    public MissingConfigurationException(String message, Throwable cause) {
+        super(message, cause, HttpStatus.BAD_REQUEST);
+    }
+}

--- a/src/main/java/org/mifos/connector/mtn/exception/MtnConnectorException.java
+++ b/src/main/java/org/mifos/connector/mtn/exception/MtnConnectorException.java
@@ -1,0 +1,25 @@
+package org.mifos.connector.mtn.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+/**
+ * Parent class for all exceptions in the MTN connector.
+ *
+ * @author amy.muhimpundu
+ */
+@Getter
+public class MtnConnectorException extends RuntimeException {
+
+    private final HttpStatus httpStatus;
+
+    public MtnConnectorException(String message, HttpStatus httpStatus) {
+        super(message);
+        this.httpStatus = httpStatus;
+    }
+
+    public MtnConnectorException(String message, Throwable cause, HttpStatus httpStatus) {
+        super(message, cause);
+        this.httpStatus = httpStatus;
+    }
+}

--- a/src/main/java/org/mifos/connector/mtn/utility/ConnectionUtils.java
+++ b/src/main/java/org/mifos/connector/mtn/utility/ConnectionUtils.java
@@ -1,5 +1,8 @@
 package org.mifos.connector.mtn.utility;
 
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
 /**
  * Connection utilities.
  */
@@ -15,5 +18,12 @@ public class ConnectionUtils {
     public static String getConnectionTimeoutDsl(final int timeout) {
         String base = "httpClient.connectTimeout={}&httpClient.connectionRequestTimeout={}&httpClient.socketTimeout={}";
         return base.replace("{}", "" + timeout);
+    }
+
+    public static String createAuthHeader(String key, String secret) {
+        key = key.replace("\n", "");
+        secret = secret.replace("\n", "");
+        byte[] credential = (key + ":" + secret).getBytes(StandardCharsets.UTF_8);
+        return Base64.getEncoder().encodeToString(credential);
     }
 }

--- a/src/main/java/org/mifos/connector/mtn/utility/ConnectionUtils.java
+++ b/src/main/java/org/mifos/connector/mtn/utility/ConnectionUtils.java
@@ -36,7 +36,7 @@ public class ConnectionUtils {
      *            the authentication key (e.g., username or client ID)
      * @param secret
      *            the authentication secret (e.g., password or client secret)
-     * @return a Basic Authentication header value in the format "Basic <Base64-encoded key:secret>"
+     * @return a Basic Authentication header value in the format "Basic Base64-encoded( key:secret )"
      * @throws MissingConfigurationException
      *             if key or secret is null
      */

--- a/src/main/java/org/mifos/connector/mtn/utility/ConnectionUtils.java
+++ b/src/main/java/org/mifos/connector/mtn/utility/ConnectionUtils.java
@@ -1,12 +1,21 @@
 package org.mifos.connector.mtn.utility;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.Base64;
+import org.mifos.connector.mtn.exception.MissingConfigurationException;
 
 /**
  * Connection utilities.
  */
 public class ConnectionUtils {
+
+    /**
+     * Private constructor to prevent instantiation.
+     */
+    private ConnectionUtils() {
+        // Utility class, no instances allowed
+    }
 
     /**
      * returns camel dsl for applying connection timeout.
@@ -20,10 +29,44 @@ public class ConnectionUtils {
         return base.replace("{}", "" + timeout);
     }
 
-    public static String createAuthHeader(String key, String secret) {
-        key = key.replace("\n", "");
-        secret = secret.replace("\n", "");
+    /**
+     * Creates a Basic Authentication header value from the provided key and secret.
+     *
+     * @param key
+     *            the authentication key (e.g., username or client ID)
+     * @param secret
+     *            the authentication secret (e.g., password or client secret)
+     * @return a Basic Authentication header value in the format "Basic <Base64-encoded key:secret>"
+     * @throws MissingConfigurationException
+     *             if key or secret is null
+     */
+    public static String createBasicAuthHeaderValue(String key, String secret) {
+        return "Basic " + createAuthHeader(key, secret);
+    }
+
+    /**
+     * Creates a Base64-encoded authentication header from the provided key and secret.
+     *
+     * @param key
+     *            the authentication key (e.g., username or client ID)
+     * @param secret
+     *            the authentication secret (e.g., password or client secret)
+     * @return a Base64-encoded string in the format "key:secret"
+     */
+    private static String createAuthHeader(String key, String secret) {
+        if (key == null || secret == null) {
+            throw new MissingConfigurationException("Key and secret must not be null");
+        }
+        // Defensive: strip control chars to prevent header injections.
+        String skipCharacters = "\n";
+        key = key.replace(skipCharacters, "");
+        secret = secret.replace(skipCharacters, "");
         byte[] credential = (key + ":" + secret).getBytes(StandardCharsets.UTF_8);
-        return Base64.getEncoder().encodeToString(credential);
+        try {
+            return Base64.getEncoder().encodeToString(credential);
+        } finally {
+            // Clear sensitive data from memory
+            Arrays.fill(credential, (byte) 0);
+        }
     }
 }

--- a/src/test/java/org/mifos/connector/mtn/utility/ConnectionUtilsTest.java
+++ b/src/test/java/org/mifos/connector/mtn/utility/ConnectionUtilsTest.java
@@ -1,0 +1,50 @@
+package org.mifos.connector.mtn.utility;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mifos.connector.mtn.exception.MissingConfigurationException;
+
+/**
+ * Connection utilities test class.
+ */
+class ConnectionUtilsTest {
+
+    private static Stream<Arguments> credentialsProvider() {
+        return Stream.of(
+                // Valid key and secret
+                Arguments.of("username", "password", "username:password"),
+                Arguments.of("user", "pass123", "user:pass123"),
+                Arguments.of("testUser", "testPass", "testUser:testPass"),
+                // Empty key and secret
+                Arguments.of("", "", ":"),
+                // Key and secret with newlines
+                Arguments.of("user\nname", "pass\nword", "username:password"));
+    }
+
+    @DisplayName("Create Base64-encoded auth header with valid key and secret")
+    @ParameterizedTest
+    @MethodSource("credentialsProvider")
+    void createAuthHeader_shouldReturnEncodedHeader(String key, String secret, String expectedDecoded) {
+        String result = ConnectionUtils.createBasicAuthHeaderValue(key, secret);
+        assertThat(result).contains("Basic ")
+                .contains(Base64.getEncoder().encodeToString(expectedDecoded.getBytes(StandardCharsets.UTF_8)));
+    }
+
+    @DisplayName("Create Base64-encoded auth header with null key or secret")
+    @Test
+    void createAuthHeader_withNullKeyOrSecret_shouldThrowNullPointerException() {
+        Assertions.assertThrows(MissingConfigurationException.class,
+                () -> ConnectionUtils.createBasicAuthHeaderValue(null, "password"));
+        Assertions.assertThrows(MissingConfigurationException.class,
+                () -> ConnectionUtils.createBasicAuthHeaderValue("username", null));
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * MTN Paybill flow: payment completion now uses Basic Authentication, improving reliability.
  * Improved error handling for missing MTN configuration (returns clear BAD_REQUEST errors).

* **Chores**
  * Bumped project version to 1.1.4.
  * Added changelog entry for 1.1.4 (2025-08-11).

* **Tests**
  * Added unit tests for Basic auth header generation and validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->